### PR TITLE
优化AB回放模块

### DIFF
--- a/src/bg/js/popup/renderList.js
+++ b/src/bg/js/popup/renderList.js
@@ -11,9 +11,11 @@ export async function renderPushInnerHtml() {
     // chrome.storage.local.get(["AcpushList1"], function (data) {
     //   $("#pop-push").append(data.AcpushList1);
     // });
-    var p1data = await db_getPushListHtml();
-    // console.log(p1data)
-    // console.log(p1data.length)
+    try {
+      var p1data = await db_getPushListHtml();
+    } catch (error) {
+      var p1data = [];
+    }
     if(p1data.length!=0){
       pushListData.index++;
       $("#pop-push").append(p1data[0].content);

--- a/src/bg/js/popup/renderList.js
+++ b/src/bg/js/popup/renderList.js
@@ -73,7 +73,7 @@ export async function renderPushInnerHtml() {
         pushListData.innerText += xmlData;
       }
       $("#pop-push").append(pushListData.innerText);
-      // pushListData.index++
+      pushListData.index++
       setTimeout(() => {
         pushListData.busy = false;
       }, 0);

--- a/src/fg/js/module/videoSetting.js
+++ b/src/fg/js/module/videoSetting.js
@@ -164,7 +164,7 @@ class VideoSetting{
                 <li class = 'point-a' data-val="A" onClick="updateAbPlayFirst()">标记点A</li>
                 <li class = 'point-b' data-val="B" onClick="updateAbPlaySecond()">标记点B</li>
                 <li class = 'switch-button' onclick="abPlayHandler();">开始</li>
-                <li onclick="stopAbPlay();">清除</li>
+                <li onclick="stopAbPlay();">清除&结束</li>
             </ul>
             <div class="transparent-placeholder"></div>
     </div>`;

--- a/src/fg/js/module/videoSettingInject.js
+++ b/src/fg/js/module/videoSettingInject.js
@@ -85,27 +85,27 @@ hiddenDiv.addEventListener('myCustomEvent', function() {
 function updateAbPlayFirst(){
     if(abPlayFlag === 1){
         leftBottomTip('请先','停止')
-        return
+        return;
     }
     let fistTime = Math.floor(document.getElementsByTagName("video")[0].currentTime);
     if(abPlaySecond && fistTime > abPlaySecond){
         leftBottomTip('A要在B之前','---鲁迅')
-        return
+        return;
     }
     abPlayFirst = fistTime;
     leftBottomTip(`标记点A :`,`${timeToMinute(abPlayFirst)}`);
-    $('.speed-panel>ul>.point-a').text(`A : ${timeToMinute(abPlayFirst)}`)
+    $('.speed-panel>ul>.point-a').text(`A : ${timeToMinute(abPlayFirst)}`);
     abPlaySecond && leftBottomTip(`区间为`,`${timeToMinute(abPlayFirst)}至${timeToMinute(abPlaySecond)}`);
 }
 function updateAbPlaySecond(){
     if(abPlayFlag === 1){
-        leftBottomTip('请先','停止')
-        return
+        leftBottomTip('请先','停止');
+        return;
     }
     let secondTime = Math.floor(document.getElementsByTagName("video")[0].currentTime);
     if(abPlayFirst && secondTime < abPlayFirst){
-        leftBottomTip('B要在A之后','---鲁迅')
-        return
+        leftBottomTip('B要在A之后','---鲁迅');
+        return;
     } 
     abPlaySecond = secondTime;
     leftBottomTip(`标记点B :`,`${timeToMinute(abPlaySecond)}`);
@@ -117,42 +117,42 @@ function updateAbPlaySecond(){
 }
 function stopAbPlay(){
     if(abPlayFlag === 1){
-        leftBottomTip('请先','停止')
-        return
+        document.getElementsByTagName("video")[0].pause();
+        abPlayFirst=abPlaySecond=undefined;
+        document.getElementsByTagName("video")[0].removeEventListener("timeupdate",abPlayMain,false);
+        abPlayFlag = 0;
+        leftBottomTip('标记已清除,已退出AB回放。');
+        $('.speed-panel>ul>.point-a').text('标记点A');
+        $('.speed-panel>ul>.point-b').text('标记点B');
+        return;
     }
     if(abPlayFirst === undefined && abPlaySecond === undefined){
-        leftBottomTip('请先设置','标记点')
-        return
+        leftBottomTip('AB回放未启用，请先设置','标记点');
+        return;
     }
-    $('.speed-panel>ul>.point-a').text('标记点A')
-    $('.speed-panel>ul>.point-b').text('标记点B')
-    abPlayFirst=abPlaySecond=undefined;
-    leftBottomTip('标记已清除') 
-}       
+}
+function abPlayMain(){
+    if(abPlayFlag==0){return};
+    if(Math.floor(window.player.currentTime) >= abPlaySecond){
+        document.getElementsByTagName("video")[0].currentTime = abPlayFirst;
+    }
+}
 function abPlayHandler(){
     if(abPlayFirst === undefined || abPlaySecond === undefined){
-        leftBottomTip('请先设置','标记点')
-        return
+        leftBottomTip('请先设置','标记点');
+        return;
     }
     if(abPlayFlag === 0){
-        leftBottomTip('AB回放','开启')
-        $('.speed-panel>ul>.switch-button').text('停止')
+        leftBottomTip('AB回放','开启');
+        document.getElementsByTagName("video")[0].removeEventListener("timeupdate",abPlayMain,false);
         document.getElementsByTagName("video")[0].currentTime = abPlayFirst;
-        document.getElementsByTagName("video")[0].removeEventListener("timeupdate")
-        document.getElementsByTagName("video")[0].addEventListener("timeupdate",function(e){
-            if(Math.floor(window.player.currentTime) >= abPlaySecond){
-                document.getElementsByTagName("video")[0].currentTime = abPlayFirst;
-            }
-        },false);
+        document.getElementsByTagName("video")[0].addEventListener("timeupdate",abPlayMain,false);
         abPlayFlag = 1;
-        return
+        return;
     }
     if(abPlayFlag === 1){
-        $('.speed-panel>ul>.switch-button').text('开始')
-        document.getElementsByTagName("video")[0].removeEventListener("timeupdate")
-        leftBottomTip('AB回放','关闭')
-        abPlayFlag = 0;
-        return
+        leftBottomTip('AB回放','已经启用，如需停止请按“清除&结束”按钮。');
+        return;
     }
 }
 function leftBottomTip(text,importantText=''){

--- a/src/fg/js/module/videoSettingInject.js
+++ b/src/fg/js/module/videoSettingInject.js
@@ -117,11 +117,11 @@ function updateAbPlaySecond(){
 }
 function stopAbPlay(){
     if(abPlayFlag === 1){
-        document.getElementsByTagName("video")[0].pause();
         abPlayFirst=abPlaySecond=undefined;
-        document.getElementsByTagName("video")[0].removeEventListener("timeupdate",abPlayMain,false);
         abPlayFlag = 0;
-        leftBottomTip('标记已清除,已退出AB回放。');
+        document.getElementsByTagName("video")[0].removeEventListener("timeupdate",abPlayMain,false);
+        $('.speed-panel>ul>.switch-button').text('开始');
+        leftBottomTip('标记已清除,退出AB回放。');
         $('.speed-panel>ul>.point-a').text('标记点A');
         $('.speed-panel>ul>.point-b').text('标记点B');
         return;
@@ -144,6 +144,7 @@ function abPlayHandler(){
     }
     if(abPlayFlag === 0){
         leftBottomTip('AB回放','开启');
+        $('.speed-panel>ul>.switch-button').text('停止');
         document.getElementsByTagName("video")[0].removeEventListener("timeupdate",abPlayMain,false);
         document.getElementsByTagName("video")[0].currentTime = abPlayFirst;
         document.getElementsByTagName("video")[0].addEventListener("timeupdate",abPlayMain,false);
@@ -151,7 +152,11 @@ function abPlayHandler(){
         return;
     }
     if(abPlayFlag === 1){
-        leftBottomTip('AB回放','已经启用，如需停止请按“清除&结束”按钮。');
+        document.getElementsByTagName("video")[0].removeEventListener("timeupdate",abPlayMain,false);
+        document.getElementsByTagName("video")[0].pause();
+        $('.speed-panel>ul>.switch-button').text('开始');
+        abPlayFlag = 0;
+        leftBottomTip('AB回放','已经关闭，如需清除标记请按“清除”按钮。');
         return;
     }
 }


### PR DESCRIPTION
1.修复AB回放函数中，事件监听器一直叠加的问题
2.修复事件监听器叠加导致在播放时，标记B点时就直接启动了回放功能的问题
3.将清除标记和退出回放合在一块，不需要再点击两个按钮才能退出了（但是会清除标记数据，可能还需要优化才行）