### PR TITLE
恢复牌子信息弹出窗

### DIFF
--- a/src/fg/modules/liveSettingInject.js
+++ b/src/fg/modules/liveSettingInject.js
@@ -16,9 +16,12 @@ let liveFunction = (function () {
             e.target.classList[0] == "user-enter"
           ) {
             let x = new Date();
-            let w = e.target.children[0].innerHTML;
-            e.target.children[0].innerHTML =
-              `<span>[${x.getHours().toString().length == 1 ? "0" + x.getHours().toString() : x.getHours()}:${x.getMinutes().toString().length == 1 ? "0" + x.getMinutes().toString() : x.getMinutes()}] </span>` + w;
+            let f_c=e.target.children[0].firstChild;
+            let span = document.createElement('span');
+            let time_hour = x.getHours().toString().length == 1 ? "0" + x.getHours().toString() : x.getHours();
+            let time_min = x.getMinutes().toString().length == 1 ? "0" + x.getMinutes().toString() : x.getMinutes();
+            span.innerHTML = `[${time_hour}:${time_min}]`;
+            e.target.children[0].insertBefore(span, f_c);
           }
         });
       clearInterval(_timer);


### PR DESCRIPTION
直播对话窗位置，鼠标悬停在牌子位置，会弹出牌子信息窗（即牌子率属UP主信息），在代码中为直接编辑<span>拼接，导致对应悬停失效，我改成用insertbefore插入span，这样能正常显示了。
#
![image](https://user-images.githubusercontent.com/34964159/109170946-37e14800-77bc-11eb-825f-c3dfa926e6f3.png)
